### PR TITLE
Switch to systemd for notify-listener background task

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -38,8 +38,10 @@ $HOME/.irssi/scripts/autorun/ folder.  Then set up a symbolic link
 to the script:
    $ ln -s ../notify.pl $HOME/.irssi/scripts/autorun/
 
-5. Start the listener int he background:
-   $ notify-listener &
+5. Setup the listener background task:
+   $ cp notify-listener.py /usr/bin/
+   $ cp irssi-libnotify.service $HOME/.config/systemd/user/
+   $ systemctl --user enable irssi-libnotify --now
 
 6. Start or restart irssi, or else load the notify script in irssi:
    /SCRIPT LOAD notify.pl

--- a/irssi-libnotify.service
+++ b/irssi-libnotify.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=irssi-libnotify-git
+
+[Service]
+ExecStart=/usr/bin/notify-listener.py
+
+[Install]
+WantedBy=default.target

--- a/notify-listener.py
+++ b/notify-listener.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2.7
 #
 # Copyright (C) 2012 Paul W. Frields <stickster@gmail.com>
 #


### PR DESCRIPTION
The latter affords persistence on the notify-listener.py script which is currently launched in background mode from a terminal session.