### PR TITLE
Fix pgrep finding multiple PIDs

### DIFF
--- a/irssi-notifier.sh
+++ b/irssi-notifier.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-NLPID=`pgrep -u $UID notify-listener`
+NLPID=$(pgrep -n -u "$UID" notify-listener)
 if [ ! -z "$NLPID" ]; then
-    DSBA=`cat /proc/$NLPID/environ | tr '\0' '\n' | grep DBUS_SESSION_BUS_ADDRESS | cut -d '=' -f2-`
+    DSBA=$(tr '\0' '\n' < "/proc/$NLPID/environ" | sed -n s/DBUS_SESSION_BUS_ADDRESS=//p)
     DBUS_SESSION_BUS_ADDRESS=$DSBA exec "$@"
 fi


### PR DESCRIPTION
I chose newest (-n) but might as well choose oldest (-o). No idea what's more likely to be the right one.

Also simplified the pipeline to extract DBUS_SESSION_BUS_ADDRESS. Perhaps even use sed -z and get rid of the tr call as well since this is all fairly GNU/Linux specific anyway as far as I can tell.