### PR TITLE
irssi-notifier.sh: support multiple gnome sessions

### DIFF
--- a/irssi-notifier.sh
+++ b/irssi-notifier.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-NLPID=`pgrep -u $UID notify-listener`
-if [ ! -z "$NLPID" ]; then
-    DSBA=`cat /proc/$NLPID/environ | tr '\0' '\n' | grep DBUS_SESSION_BUS_ADDRESS | cut -d '=' -f2-`
+for pid in `pgrep -u $UID notify-listener`; do
+    DSBA=`cat /proc/$pid/environ | tr '\0' '\n' | grep DBUS_SESSION_BUS_ADDRESS | cut -d '=' -f2-`
     DBUS_SESSION_BUS_ADDRESS=$DSBA exec "$@"
-fi
+done


### PR DESCRIPTION
A user may have multiple instances of notify-listener running under
different gnome sessions, so if pgrep returns multiple processes,
irssi-notifier.sh dumps error messages in the chat window as a result.

14:09 cat: /proc/2027: Is a directory
14:09 cat: 3035/environ: No such file or directory